### PR TITLE
Multiple passwords support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .deps
+.dirstamp
 .libs
 Makefile
 Makefile.in


### PR DESCRIPTION
This checks for each rows if multiple password hashes are returned by the query.
It doesn't break the existing behaviour.